### PR TITLE
Clicking map items only on map view

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -18,10 +18,6 @@ import dataEN from './streets_en.json';
 import dataPL from './streets_pl.json';
 import {useI18n} from './utils/locale/I18n';
 
-const BREAKPOINT = 1024;
-const SCREEN_MOBILE = 'SCREEN_MOBILE';
-const SCREEN_DESKTOP = 'SCREEN_DESKTOP';
-
 export type PhotoType = {
   title: string,
   small: string,
@@ -51,21 +47,11 @@ type StateType = {
   data: Array<StreetType>,
 };
 
-function widthToScreenType(width: number) {
-  if (width <= BREAKPOINT) {
-    return SCREEN_MOBILE;
-  }
-
-  return SCREEN_DESKTOP;
-}
-
 function AppContainer() {
   const {getRoute, locale} = useI18n();
   const [{data}, setState] = useState<StateType>({
     data: locale === 'pl' ? dataPL : dataEN,
   });
-  const screenType = widthToScreenType(window.innerWidth);
-  const isWideLayout = screenType === SCREEN_DESKTOP;
 
   useEffect(() => {
     setState(state => ({...state, data: locale === 'pl' ? dataPL : dataEN}));

--- a/src/components/list/Street.jsx
+++ b/src/components/list/Street.jsx
@@ -10,6 +10,7 @@ import {slugifyStreetName} from '../../utils/url';
 
 import type {RouterHistory} from 'react-router-dom';
 import type {PlacesType} from '../../AppContainer';
+import {getScreenType, SCREEN_MOBILE} from '../../utils/screenType';
 
 import style from './list.css';
 import {useI18n} from '../../utils/locale/I18n';
@@ -27,6 +28,7 @@ function Street({name, id, mapView, places}: PropsType) {
   const slugName = slugifyStreetName(name);
   const path = generateRoute('MAP', {name: slugName});
   const isActive = useRouteMatch(path);
+  const canBeClicked = !(!mapView && getScreenType() === SCREEN_MOBILE);
 
   return (
     <div
@@ -41,7 +43,7 @@ function Street({name, id, mapView, places}: PropsType) {
       </style>
       <div
         className={style.listItemCover}
-        onClick={() => history.push(path)}
+        onClick={() => canBeClicked ? history.push(path) : undefined}
       ></div>
       <Link
         to={generateRoute('STREET', {

--- a/src/utils/screenType.js
+++ b/src/utils/screenType.js
@@ -1,0 +1,19 @@
+// @flow
+
+export const SCREEN_MOBILE = 'SCREEN_MOBILE';
+export const SCREEN_DESKTOP = 'SCREEN_DESKTOP';
+const BREAKPOINT = 1024;
+
+export type ScreenType = 'SCREEN_MOBILE' | 'SCREEN_DESKTOP';
+
+function widthToScreenType(width: number): ScreenType {
+  if (width <= BREAKPOINT) {
+    return SCREEN_MOBILE;
+  }
+
+  return SCREEN_DESKTOP;
+}
+
+export function getScreenType(): ScreenType {
+  return widthToScreenType(window.innerWidth);
+}

--- a/src/utils/screenType.spec.js
+++ b/src/utils/screenType.spec.js
@@ -1,0 +1,17 @@
+// @flow
+
+import {getScreenType, SCREEN_MOBILE, SCREEN_DESKTOP} from './screenType';
+
+describe('getScreenType()', () => {
+  it ('returns "SCREEN_MOBILE" when viewport is smaller than breakpoint', () => {
+    global.window.innerWidth = 480;
+
+    expect(getScreenType()).toEqual(SCREEN_MOBILE);
+  });
+
+  it ('returns "SCREEN_DESKTOP" when viewport is greater than breakpoint', () => {
+    global.window.innerWidth = 1280;
+
+    expect(getScreenType()).toEqual(SCREEN_DESKTOP);
+  });
+});

--- a/src/utils/screenType.spec.js
+++ b/src/utils/screenType.spec.js
@@ -3,13 +3,13 @@
 import {getScreenType, SCREEN_MOBILE, SCREEN_DESKTOP} from './screenType';
 
 describe('getScreenType()', () => {
-  it ('returns "SCREEN_MOBILE" when viewport is smaller than breakpoint', () => {
+  it('returns "SCREEN_MOBILE" when viewport is smaller than breakpoint', () => {
     global.window.innerWidth = 480;
 
     expect(getScreenType()).toEqual(SCREEN_MOBILE);
   });
 
-  it ('returns "SCREEN_DESKTOP" when viewport is greater than breakpoint', () => {
+  it('returns "SCREEN_DESKTOP" when viewport is greater than breakpoint', () => {
     global.window.innerWidth = 1280;
 
     expect(getScreenType()).toEqual(SCREEN_DESKTOP);


### PR DESCRIPTION
We allow clicking the list items (that open map) only on map view, otherwise only arrows are clickable. Desktop not affected.